### PR TITLE
Update LocationBackendService.java

### DIFF
--- a/api/src/org/microg/nlp/api/LocationBackendService.java
+++ b/api/src/org/microg/nlp/api/LocationBackendService.java
@@ -36,6 +36,9 @@ public abstract class LocationBackendService extends Service {
 		if (callback != null) {
 			try {
 				callback.report(location);
+			} catch (android.os.DeadObjectException e) {
+				waiting = location;
+				callback = null;
 			} catch (RemoteException e) {
 				waiting = location;
 			}


### PR DESCRIPTION
DeadObjectException is thrown if the callback is invalid (has died). The callback should thus be set to "null" or we'll get an infinite series of exceptions :-)
