### PR TITLE
Do not keep a dead backend open.

### DIFF
--- a/src/org/microg/nlp/location/BackendHelper.java
+++ b/src/org/microg/nlp/location/BackendHelper.java
@@ -57,6 +57,7 @@ public class BackendHelper implements BackendHandler {
 			} catch (Exception e) {
 				Log.w(TAG, e);
 			}
+			bound = false;
 		}
 	}
 


### PR DESCRIPTION
Do not try to unbind forever if the backend died (e.g. DeadObjectException).

Currently reinstalling an active backend may result in infinite exception spamming as dead backends are marked "bound" and can never unbind (IllegalArgumentException).

Make only one try to unbind.
