### PR TITLE
Report a new location only after receiving a non-null update

### DIFF
--- a/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendFuser.java
+++ b/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendFuser.java
@@ -78,7 +78,7 @@ class BackendFuser {
     }
 
     public void update() {
-        Boolean hasUpdates = false;
+        boolean hasUpdates = false;
         fusing = true;
         for (BackendHelper handler : backendHelpers) {
             if (handler.update() != null)

--- a/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendFuser.java
+++ b/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendFuser.java
@@ -135,11 +135,14 @@ class BackendFuser {
     }
 
     public void forceLocation(Location location) {
+    	if ((forcedLocation != null) && (location != null) && (forcedLocation.getTime() >= location.getTime()))
+    		return;
         forcedLocation = location;
         if (forcedLocation != null) {
             Bundle extras = new Bundle();
             extras.putString(LOCATION_EXTRA_BACKEND_PROVIDER, "forced");
             location.setExtras(extras);
+            reportLocation();
         }
     }
 

--- a/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendFuser.java
+++ b/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendFuser.java
@@ -78,12 +78,15 @@ class BackendFuser {
     }
 
     public void update() {
+        Boolean hasUpdates = false;
         fusing = true;
         for (BackendHelper handler : backendHelpers) {
-            handler.update();
+            if (handler.update() != null)
+                hasUpdates = true;
         }
         fusing = false;
-        updateLocation();
+        if (hasUpdates)
+            updateLocation();
     }
 
     void updateLocation() {

--- a/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendHelper.java
+++ b/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendHelper.java
@@ -69,7 +69,7 @@ class BackendHelper extends AbstractBackendHelper {
             updateWaiting = false;
             try {
                 result = backend.update();
-                if (result != null) {
+                if ((result != null) && (result.getTime() > lastLocation.getTime())) {
                     setLastLocation(result);
                     backendFuser.reportLocation();
                 }
@@ -150,7 +150,7 @@ class BackendHelper extends AbstractBackendHelper {
     private class Callback extends LocationCallback.Stub {
         @Override
         public void report(Location location) throws RemoteException {
-            if (location == null)
+            if ((location == null) || (location.getTime() <= lastLocation.getTime()))
                 return;
             setLastLocation(location);
             backendFuser.reportLocation();

--- a/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendHelper.java
+++ b/unifiednlp-base/src/main/java/org/microg/nlp/location/BackendHelper.java
@@ -54,20 +54,31 @@ class BackendHelper extends AbstractBackendHelper {
         return lastLocation;
     }
 
-    public void update() {
+    /**
+     * @brief Requests a location update from the backend.
+     * 
+     * @return The location reported by the backend. This may be null if a backend cannot determine its
+     * location, or if it is going to return a location asynchronously.
+     */
+    public Location update() {
+        Location result = null;
         if (backend == null) {
             Log.d(TAG, "Not (yet) bound.");
             updateWaiting = true;
         } else {
             updateWaiting = false;
             try {
-                setLastLocation(backend.update());
-                backendFuser.reportLocation();
+                result = backend.update();
+                if (result != null) {
+                    setLastLocation(result);
+                    backendFuser.reportLocation();
+                }
             } catch (Exception e) {
                 Log.w(TAG, e);
                 unbind();
             }
         }
+        return result;
     }
 
     private void setLastLocation(Location location) {
@@ -139,6 +150,8 @@ class BackendHelper extends AbstractBackendHelper {
     private class Callback extends LocationCallback.Stub {
         @Override
         public void report(Location location) throws RemoteException {
+            if (location == null)
+                return;
             setLastLocation(location);
             backendFuser.reportLocation();
         }


### PR DESCRIPTION
Prevents stale locations from being re-sent when backends supply null locations, fixes #75 