### PR TITLE
Allow location providers also outside of /system

### DIFF
--- a/patches/android_frameworks_base-N.patch
+++ b/patches/android_frameworks_base-N.patch
@@ -1,0 +1,14 @@
+diff --git a/services/core/java/com/android/server/ServiceWatcher.java b/services/core/java/com/android/server/ServiceWatcher.java
+index 383e25a..31ae918 100644
+--- a/services/core/java/com/android/server/ServiceWatcher.java
++++ b/services/core/java/com/android/server/ServiceWatcher.java
+@@ -92,8 +92,7 @@ public class ServiceWatcher implements ServiceConnection {
+             String pkg = initialPackageNames.get(i);
+             try {
+                 HashSet<Signature> set = new HashSet<Signature>();
+-                Signature[] sigs = pm.getPackageInfo(pkg, PackageManager.MATCH_SYSTEM_ONLY
+-                        | PackageManager.GET_SIGNATURES).signatures;
++                Signature[] sigs = pm.getPackageInfo(pkg, PackageManager.GET_SIGNATURES).signatures;
+                 set.addAll(Arrays.asList(sigs));
+                 sigSets.add(set);
+             } catch (NameNotFoundException e) {


### PR DESCRIPTION
This restores the behavior of android M. Tested on AOSP 7.0.0_r14.
Closes https://github.com/microg/android_packages_apps_UnifiedNlp/issues/102