### PR TITLE
Fix typo in strings

### DIFF
--- a/unifiednlp-base/src/main/res/values/strings.xml
+++ b/unifiednlp-base/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="self_check_name_nlp_bound">UnifiedNlp is registered in system:</string>
     <string name="self_check_resolution_nlp_bound">The system did not bind the UnifiedNlp service. If you just installed UnifiedNlp you should try to reboot this device.</string>
     <string name="self_check_name_nlp_setup">Location backend(s) set up:</string>
-    <string name="self_check_resolution_nlp_setup">Install and configure a UnifiedNlp location backend to use network-based geolocation,</string>
+    <string name="self_check_resolution_nlp_setup">Install and configure a UnifiedNlp location backend to use network-based geolocation.</string>
     <string name="self_check_name_last_location">UnifiedNlp has known location:</string>
     <string name="self_check_resolution_last_location">UnifiedNlp has no last known location. This will cause some apps to fail.</string>
     <string name="self_check_name_nlp_is_providing">UnifiedNlp provides location updates:</string>


### PR DESCRIPTION
Again, spotted while working on french translation.

This might require fixing in the other languages too (just checked Serbian, which is affected). I didn’t verified it for GmsCore either. Would you want me to check both and push commits to fix if necessary or will you handle it?