### PR TITLE
Fix sdk platform

### DIFF
--- a/unifiednlp-compat/build.gradle
+++ b/unifiednlp-compat/build.gradle
@@ -25,5 +25,5 @@ if (!sdkDir) {
 
 sourceSets.main {
     java.srcDirs = ['src/current/java', 'src/v9/java']
-    compileClasspath += project.rootProject.files("$sdkDir/platforms/android-25/android.jar")
+    compileClasspath += project.rootProject.files("$sdkDir/platforms/android-27/android.jar")
 }


### PR DESCRIPTION
It seems sdk platform-27 is used to build. But in build.gradle it ask for platform-25, so I updated the value.